### PR TITLE
[feat] extendable tokenizer

### DIFF
--- a/ml/src/tokenizer.py
+++ b/ml/src/tokenizer.py
@@ -47,12 +47,10 @@ class CodeplayTokenizer(MMM):
             return self.push_to_hub(repo_id=repo_id, **kwargs)
         return None
 
-#NOTE - maximus 64 genre tokens
-GENRE_TOKEN_LIST = ['Rock', 'Pop', 'Jazz', 'Unk']
-GENRE_TOKEN_LIST = ['Genre_'+genre for genre in GENRE_TOKEN_LIST]
-
-#NOTE - maximus 64 cut tokens
-CUT_TOKEN_LIST = ['Cut_'+str(i) for i in range(64)] + ['Cut_Unk']
+GENRE_TOKEN_LIST = ['Rock', 'Pop', 'Jazz']
+GENRE_TOKEN_LIST = ['Genre_Unk'] + ['Genre_'+genre for genre in GENRE_TOKEN_LIST]
+GENRE_TOKEN_LIST += ['Genre_'+str(i+1) for i in range(40-len(GENRE_TOKEN_LIST))] #40
+CUT_TOKEN_LIST = ['Cut_Unk'] + ['Cut_'+str(i+1) for i in range(63)] # 64
 
 def get_custom_tokenizer():
     TOKENIZER_NAME = CodeplayTokenizer
@@ -65,25 +63,20 @@ def get_custom_tokenizer():
     
     # MMM tokenizer
     mmm = len(tokenizer)-1
-    print(f'MMM Tokenizer bandwith : 0 ~ {mmm}')
+    print(f'MMM Tokenizer bandwith : 0 ~ {mmm}, ({mmm+1} tokens)')
     
     # Add genre token
     for genre_tk in GENRE_TOKEN_LIST:
         tokenizer.add_to_vocab(genre_tk)
-    # Add genre Unused token
-    for i in range(40-len(GENRE_TOKEN_LIST)):
-        tokenizer.add_to_vocab(f'Genre_{i}')
     genre = len(tokenizer)-1
-    print(f'Genre Tokenizer bandwith : {mmm+1} ~ {genre}')
+    print(f'Genre Tokenizer bandwith : {mmm+1} ~ {genre}, ({genre-mmm} tokens)')
     
     # Add cut(bar4) token
     for cut_tk in CUT_TOKEN_LIST:
         tokenizer.add_to_vocab(cut_tk)
     # Add cut Unused token
-    for i in range(64-len(CUT_TOKEN_LIST)):
-        tokenizer.add_to_vocab(f'Cut_{i}')
     cut = len(tokenizer)-1
-    print(f'Cut Tokenizer bandwith : {genre+1} ~ {cut}')
+    print(f'Cut Tokenizer bandwith : {genre+1} ~ {cut}, ({cut-genre} tokens)')
     
     print(f'Total Tokenizer bandwith : 0 ~ {cut}, ({len(tokenizer)} tokens)')
     return tokenizer


### PR DESCRIPTION
## 개요

 기존 MMM 토큰,
그리고 커스터마이징을 위한 다양한 토큰 (장르, cut(bar4) 등...)을 위한 extendable tokenizer 설정하였습니다.

기존에는 서로 달리 커스터마이징을 하면 vocab id가 뒤죽박죽돼서 학습 파라미터를 공유 못하는 경우 있었는데
bandwith정해서 기존 토큰들이 고정된 vocab id를 갖도록 했습니다.

![image](https://github.com/boostcampaitech6/level2-3-nlp-finalproject-nlp-07/assets/19660039/005e2e0c-2698-4100-be2b-32a1ea9468c1)


#8 