### PR TITLE
[ml] overlap 기능 추가

### DIFF
--- a/ml/src/load_data.py
+++ b/ml/src/load_data.py
@@ -188,8 +188,20 @@ class CodeplayDataset(_DatasetABC):
         ):
             label = None
             midi, cut_idx = midis[i]
-            tokens = tokenizer(midi)
-            tokens_ids = tokens.ids
+            tokens = tokenizer(midi).tokens
+            
+            nnn_tokens = []
+            i = 0
+            while i < len(tokens):
+                tk = tokens[i]
+                if tk.startswith('Pitch_'):
+                    new_tk = f'{tokens[i]}+{tokens[i+1]}+{tokens[i+2]}'
+                    nnn_tokens.append(new_tk)
+                    i += 3
+                else:
+                    nnn_tokens.append(tk)
+                    i += 1
+            tokens_ids = [tokenizer[tk] for tk in nnn_tokens]
                 
             #TODO - path -> midi 구조 변경으로 인한 수정 필요
             # Concat genre token

--- a/ml/src/tokenizer.py
+++ b/ml/src/tokenizer.py
@@ -80,3 +80,28 @@ def get_custom_tokenizer():
     
     print(f'Total Tokenizer bandwith : 0 ~ {cut}, ({len(tokenizer)} tokens)')
     return tokenizer
+
+def get_nnn_tokenizer():
+    NNN = CodeplayTokenizer
+    config = TokenizerConfig(
+        num_velocities=8,
+        use_programs=True
+    )
+    tokenizer = NNN(config)
+    prev_len = len(tokenizer)
+    vocabs = list(tokenizer.vocab.keys())
+    
+    pitches = [v for v in vocabs if v.startswith('Pitch_') ]
+    velocities = [v for v in vocabs if v.startswith('Velocity_') ]
+    durations = [v for v in vocabs if v.startswith('Duration_') ]
+    
+    for p in pitches:
+        for v in velocities:
+            for d in durations:
+                new_tk = f'{p}+{v}+{d}'
+                tokenizer.add_to_vocab(new_tk)
+    
+    print(f'MMM Tokenizer bandwith : 0 ~ {prev_len}, ({prev_len} tokens)')
+    print(f'NNN Tokenizer bandwith : {prev_len} ~ {len(tokenizer)}, ({len(tokenizer)-prev_len} tokens)')
+    return tokenizer
+    

--- a/ml/src/train.py
+++ b/ml/src/train.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 
 from transformers import AutoConfig, GPT2LMHeadModel, set_seed, EarlyStoppingCallback, TrainingArguments
-from tokenizer import get_custom_tokenizer
+from tokenizer import get_custom_tokenizer, get_nnn_tokenizer
 from miditok.pytorch_data import DataCollator
 from load_data import load_midi_paths, CodeplayDataset, chunk_midi, overlap_chunk_midi
 from trainer import CodeplayTrainer
@@ -28,7 +28,8 @@ MAX_SEQ_LEN, BATCH_SIZE = 1024, 16
 # MAX_SEQ_LEN, BATCH_SIZE = 512, 32
 
 def main():
-    tokenizer = get_custom_tokenizer()
+    # tokenizer = get_custom_tokenizer()
+    tokenizer = get_nnn_tokenizer()
     
     midi_paths = ['../data/full/jazz-midi-clean']
     print(midi_paths)
@@ -54,9 +55,9 @@ def main():
     context_length = MAX_SEQ_LEN
 
     #TODO: Change this based on size of the data
-    n_layer=12
-    n_head=12
-    n_emb=384
+    n_layer=6
+    n_head=6
+    n_emb=768
 
     # gpt2 config
     model_config = AutoConfig.from_pretrained(
@@ -81,13 +82,13 @@ def main():
     
     # Get the output directory with timestamp.
     # output_path with timestamp
-    DATASET_NAME = 'jazz-midi-clean'
+    DATASET_NAME = 'jazz-NNN'
     output_path = "../models/" + datetime.now().strftime("%Y%m%d-%H%M%S") + "_" + DATASET_NAME
     steps = 400
     # Commented parameters correspond to the small model
     trainer_config = {
         "output_dir": output_path,
-        "num_train_epochs": 30, # 학습 epoch 자유롭게 변경. 저는 30 epoch 걸어놓고 early stopping 했습니다.
+        "num_train_epochs": 40, # 학습 epoch 자유롭게 변경. 저는 30 epoch 걸어놓고 early stopping 했습니다.
         "per_device_train_batch_size": BATCH_SIZE,
         "per_device_eval_batch_size": BATCH_SIZE,
         "evaluation_strategy": "steps",


### PR DESCRIPTION
## overlap_chunking
- load_data.py
- def overlap_chunk_midi(midi_paths:list[Path], chunk_bar_num=4, overlap=2):
- (4마디 단위로 청킹하고, 2마디씩 overlap)하도록
- 오버랩해서 학습시키도록 했습니다.
- 데이터 증강 효과 ( 4/2 기준 2배 )
- 기존에는 무조건 4마디 단위로 생성가능했는데, 오버랩함으로써 모델 스스로 마디를 연장해서 조금씩 더 길게 생성할 수 있음
- 다만 성능은 아직 안 좋음. 메타정보를 입력해줄 수 있는 토큰이 필요할 것이라는 생각.

## 학습 시 모델 폴더명에 학습일시 추가
- 기존에는 models 아래에 checkpoint-nStep으로만 기록되었음. 덮어씌워짐.
- models/{datetime}-{DATA_NAME} 방식으로 경로 지정 가능
